### PR TITLE
Removed username property from UserInterface and replaced it with email

### DIFF
--- a/metadata/charcoal/user/auth-token.json
+++ b/metadata/charcoal/user/auth-token.json
@@ -7,7 +7,7 @@
         "token": {
             "type": "string"
         },
-        "username": {
+        "user_id": {
             "type": "string"
         },
         "expiry": {

--- a/metadata/charcoal/user/user-interface.json
+++ b/metadata/charcoal/user/user-interface.json
@@ -1,13 +1,18 @@
 {
     "properties": {
-        "username": {
-            "type": "string",
+        "id": {
+            "type": "id",
+            "mode": "uuid"
+        },
+        "email": {
+            "type": "email",
             "unique": true,
             "required": true,
+            "allow_empty": false,
             "allow_null": false,
             "label": {
-                "en": "Username",
-                "fr": "Nom d'utilisateur"
+                "en": "Email Address",
+                "fr": "Adresse Courriel"
             }
         },
         "password": {
@@ -20,14 +25,12 @@
                 "fr": "Mot de passe"
             }
         },
-        "email": {
-            "type": "email",
+        "display_name": {
+            "type": "string",
             "required": true,
-            "allow_empty": false,
-            "allow_null": false,
             "label": {
-                "en": "Email Address",
-                "fr": "Adresse Courriel"
+                "en": "Display Name",
+                "fr": "Nom d'affichage"
             }
         },
         "roles": {
@@ -87,7 +90,5 @@
                 "fr": "Préférences"
             }
         }
-    },
-
-    "key": "username"
+    }
 }

--- a/src/Charcoal/User/AbstractUser.php
+++ b/src/Charcoal/User/AbstractUser.php
@@ -566,7 +566,7 @@ abstract class AbstractUser extends Content implements
 
 
 
-    // Extends \Charcoal\Validator\ValidatableTrait
+    // Extends Charcoal\Validator\ValidatableTrait
     // =========================================================================
 
     /**

--- a/src/Charcoal/User/AuthTokenMetadata.php
+++ b/src/Charcoal/User/AuthTokenMetadata.php
@@ -28,7 +28,7 @@ class AuthTokenMetadata extends ModelMetadata
     private $cookieDuration;
 
     /**
-     * @var bool $httpsOnly
+     * @var boolean $httpsOnly
      */
     private $httpsOnly;
 

--- a/src/Charcoal/User/Authenticator.php
+++ b/src/Charcoal/User/Authenticator.php
@@ -96,7 +96,7 @@ class Authenticator implements LoggerAwareInterface
     /**
      * Attempt to authenticate a user using the given credentials.
      *
-     * @param string $email Email, part of necessary credentials.
+     * @param string $email    Email, part of necessary credentials.
      * @param string $password Password, part of necessary credentials.
      * @throws InvalidArgumentException If email or password are invalid or empty.
      * @return \Charcoal\User\UserInterface|null Returns the authenticated user object

--- a/src/Charcoal/User/UserInterface.php
+++ b/src/Charcoal/User/UserInterface.php
@@ -16,21 +16,6 @@ interface UserInterface extends ContentInterface
     public static function sessionKey();
 
     /**
-     * Force a lowercase username
-     *
-     * @param string $username The username (also the login name).
-     * @return UserInterface Chainable
-     */
-    public function setUsername($username);
-
-    /**
-     * The username is also used as login name and main identifier (key).
-     *
-     * @return string
-     */
-    public function username();
-
-    /**
      * @param string $email The user email.
      * @return UserInterface Chainable
      */
@@ -51,6 +36,17 @@ interface UserInterface extends ContentInterface
      * @return string
      */
     public function password();
+
+    /**
+     * @param  string|null $name The user's display name.
+     * @return UserInterface Chainable
+     */
+    public function setDisplayName($name);
+
+    /**
+     * @return string|null
+     */
+    public function displayName();
 
     /**
      * @param string|string[]|null $roles The ACL roles this user belongs to.

--- a/tests/Charcoal/User/AbstractUserTest.php
+++ b/tests/Charcoal/User/AbstractUserTest.php
@@ -50,11 +50,8 @@ class AbstractUserTest extends AbstractTestCase
             AbstractUser::class,
             [
                 [
-                    # 'container'        => $container,
-                    'logger'           => $container['logger'],
-                    'translator'       => $container['translator'],
-                    # 'property_factory' => $container['property/factory'],
-                    # 'metadata_loader'  => $container['metadata/loader']
+                    'logger'     => $container['logger'],
+                    'translator' => $container['translator'],
                 ]
             ],
             '',
@@ -111,17 +108,6 @@ class AbstractUserTest extends AbstractTestCase
         $this->assertEquals('token', $obj->loginToken());
         $this->assertFalse($obj->active());
     }
-
-    /**
-     * @return void
-     */
-    /*public function testSetDataDoesNotSetPassword()
-    {
-        $obj = $this->obj;
-        $this->assertNull($obj->password());
-        $obj->setData(['password'=>'password123']);
-        $this->assertNull($obj->password())
-    }*/
 
     /**
      * @return void
@@ -299,7 +285,6 @@ class AbstractUserTest extends AbstractTestCase
         $this->assertSame($ret, $this->obj);
 
         $this->obj['id'] = 'bar';
-        //$ret = $this->obj->resetPassword('foo');
 
         $this->expectException(InvalidArgumentException::class);
         $this->obj->resetPassword(false);

--- a/tests/Charcoal/User/AbstractUserTest.php
+++ b/tests/Charcoal/User/AbstractUserTest.php
@@ -75,7 +75,7 @@ class AbstractUserTest extends AbstractTestCase
     public function testKey()
     {
         $obj = $this->obj;
-        $this->assertEquals('username', $obj->key());
+        $this->assertEquals('id', $obj->key());
     }
 
     /**
@@ -99,14 +99,14 @@ class AbstractUserTest extends AbstractTestCase
     {
         $obj = $this->obj;
         $ret = $obj->setData([
-            'username'   => 'Foo',
+            'id'         => 'foo',
             'email'      => 'test@example.com',
             'roles'      => [ 'foo', 'bar' ],
             'loginToken' => 'token',
             'active'     => false
         ]);
         $this->assertSame($ret, $obj);
-        $this->assertEquals('foo', $obj->username());
+        $this->assertEquals('foo', $obj->id());
         $this->assertEquals('test@example.com', $obj->email());
         $this->assertEquals('token', $obj->loginToken());
         $this->assertFalse($obj->active());
@@ -122,36 +122,6 @@ class AbstractUserTest extends AbstractTestCase
         $obj->setData(['password'=>'password123']);
         $this->assertNull($obj->password())
     }*/
-
-    /**
-     * @return void
-     */
-    public function testSetUsername()
-    {
-        $ret = $this->obj->setUsername('Foobar');
-        $this->assertSame($ret, $this->obj);
-        $this->assertEquals('foobar', $this->obj->username());
-
-        $this->obj['username'] = 'Baz';
-        $this->assertEquals('baz', $this->obj->username());
-
-        $this->obj->set('username', 'FOO');
-        $this->assertEquals('foo', $this->obj['username']);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->obj->setUsername(false);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIdIsUsername()
-    {
-        $this->assertequals('username', $this->obj->key());
-        $this->obj->setUsername('foo');
-        $this->assertEquals('foo', $this->obj->id());
-        $this->assertEquals($this->obj->id(), $this->obj->username());
-    }
 
     /**
      * @return void
@@ -328,7 +298,7 @@ class AbstractUserTest extends AbstractTestCase
         $ret = $this->obj->resetPassword('foo');
         $this->assertSame($ret, $this->obj);
 
-        $this->obj['username'] = 'bar';
+        $this->obj['id'] = 'bar';
         //$ret = $this->obj->resetPassword('foo');
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Charcoal/User/AuthTokenTest.php
+++ b/tests/Charcoal/User/AuthTokenTest.php
@@ -80,23 +80,14 @@ class AuthTokenTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testSetUsername()
+    public function testSetUserId()
     {
-        $ret = $this->obj->setUsername('foo');
+        $ret = $this->obj->setUserId('foo');
         $this->assertSame($ret, $this->obj);
-        $this->assertEquals('foo', $this->obj->username());
+        $this->assertEquals('foo', $this->obj->userId());
 
         $this->expectException('\Exception');
-        $this->obj->setUsername([]);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSetUsernameIsLowercase()
-    {
-        $this->obj->setUsername('FÔOBÄR');
-        $this->assertEquals('fôobär', $this->obj->username());
+        $this->obj->setUserId([]);
     }
 
     /**

--- a/tests/Charcoal/User/AuthTokenTest.php
+++ b/tests/Charcoal/User/AuthTokenTest.php
@@ -42,10 +42,8 @@ class AuthTokenTest extends AbstractTestCase
 
         $this->obj = $container['model/factory']->create(AuthToken::class);
         $this->obj = new AuthToken([
-            # 'container'        => $container,
-            'logger'           => $container['logger'],
-            # 'property_factory' => $container['property/factory'],
-            'metadata_loader'  => $container['metadata/loader']
+            'logger'          => $container['logger'],
+            'metadata_loader' => $container['metadata/loader']
         ]);
     }
 

--- a/tests/Charcoal/User/AuthenticatorTest.php
+++ b/tests/Charcoal/User/AuthenticatorTest.php
@@ -73,7 +73,7 @@ class AuthenticatorTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testAuthenticateByPasswordInvalidUsername()
+    public function testAuthenticateByPasswordInvalidEmail()
     {
         $this->expectException('\InvalidArgumentException');
         $this->obj->authenticateByPassword([], '');

--- a/tests/Charcoal/User/GenericUserTest.php
+++ b/tests/Charcoal/User/GenericUserTest.php
@@ -73,9 +73,9 @@ class GenericUserTest extends AbstractTestCase
         $obj = $this->obj;
 
         $sessionKey = $obj::sessionKey();
-        $this->obj['username'] = 'foo';
+        $this->obj['id'] = 'foo';
         $this->obj->saveToSession();
-        $this->assertEquals($_SESSION[$sessionKey], $this->obj['username']);
+        $this->assertEquals($_SESSION[$sessionKey], $this->obj['id']);
     }
 
     /**


### PR DESCRIPTION
## Breaking changes

- Changed UserInterface key to new `id` property
- Removed `username` property from UserInterface
- Changed `username` property to `user_id` on AuthToken
- Updated Authenticator to work with the `email` property.

## New features

- Added a `display_name` property to UserInterface
- Added validation on AbstractUser, checking for non-uniqueness of chosen email.