### PR TITLE
Replace ACL component from Zend with Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Charcoal User
 =============
 
-User defintion (as Charcoal Model), authentication and authorization (with Zend ACL).
+User defintion (as Charcoal Model), authentication and authorization (with Laminas ACL).
 
 
 # Table of content
@@ -27,7 +27,7 @@ The preferred (and only supported) way of installing _charcoal-user_ is with **c
 ## Dependencies
 
 - PHP 7.1+
-- `zendframework/zend-permissions-acl`
+- `laminas/laminas-permissions-acl`
 - `locomotivemtl/charcoal-object`
 
 # The User object
@@ -75,7 +75,7 @@ For quick prototypes or small projects, a full concrete class is provided as `\C
 
 # Authorization
 
-User authorization is managed with a role-based _Access Control List_ (ACL). Internally, it uses [`zendframework/zend-permissions-acl`](https://github.com/zendframework/zend-permissions-acl) for the ACL logic. It is recommended to read the  [Zend ACL documentation](https://zendframework.github.io/zend-permissions-acl/) to learn more about how it all works.
+User authorization is managed with a role-based _Access Control List_ (ACL). Internally, it uses [`laminas/laminas-permissions-acl`](https://github.com/laminas/laminas-permissions-acl) for the ACL logic. It is recommended to read the  [Laminas ACL documentation](https://docs.laminas.dev/laminas-permissions-acl/) to learn more about how it all works.
 
 There are 2 main concepts that must be managed, either from JSON config files or in the database (which works well with `locomotivemtl/charcoal-admin`), **roles** and **permissions**.
 
@@ -102,9 +102,8 @@ To set up ACL, it is highly recommended to use the `\Charcoal\User\Acl\Manager`.
 ```
 
 ```php
-// Dependencies from `zendframework/zend-permissions`
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Resource\GenericResource as AclResource;
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Resource\GenericResource as AclResource;
 
 // Dependencies from `charcoal-user`
 use Charcoal\User\Acl\Manager as AclManager;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">7.1",
         "psr/log": "^1.0",
-        "zendframework/zend-permissions-acl": "^2.6",
+        "laminas/laminas-permissions-acl": "^2.7",
         "locomotivemtl/charcoal-object": "~0.7",
         "locomotivemtl/charcoal-config": "~0.10",
         "locomotivemtl/charcoal-factory": "~0.4",

--- a/src/Charcoal/User/Acl/Manager.php
+++ b/src/Charcoal/User/Acl/Manager.php
@@ -9,9 +9,9 @@ use PDOException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
-// From 'zendframework/zend-permissions'
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Role\GenericRole;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Role\GenericRole;
 
 /**
  * Manage ACL roles and permissions from config (arrays) or database.
@@ -32,9 +32,9 @@ class Manager implements LoggerAwareInterface
     }
 
     /**
-     * @param Acl    $acl         The Zend Acl instant to load permissions to.
-     * @param array  $permissions The array of permissions, in [role=>details] array.
-     * @param string $resource    The Acl resource (string identifier) to load roles and permissions into.
+     * @param  Acl    $acl         The Laminas Acl instant to load permissions to.
+     * @param  array  $permissions The array of permissions, in [role=>details] array.
+     * @param  string $resource    The Acl resource (string identifier) to load roles and permissions into.
      * @return void
      */
     public function loadPermissions(Acl &$acl, array $permissions, $resource = '')
@@ -45,10 +45,10 @@ class Manager implements LoggerAwareInterface
     }
 
     /**
-     * @param Acl    $acl      The Zend Acl instance to load permissions to.
-     * @param PDO    $dbh      The PDO database instance.
-     * @param string $table    The table where to fetch the roles and permissions.
-     * @param string $resource The Acl resource (string identifier) to load roles and permissions into.
+     * @param  Acl    $acl      The Laminas Acl instance to load permissions to.
+     * @param  PDO    $dbh      The PDO database instance.
+     * @param  string $table    The table where to fetch the roles and permissions.
+     * @param  string $resource The Acl resource (string identifier) to load roles and permissions into.
      * @return void
      */
     public function loadDatabasePermissions(Acl &$acl, PDO $dbh, $table, $resource = '')
@@ -75,10 +75,10 @@ class Manager implements LoggerAwareInterface
     }
 
     /**
-     * @param Acl    $acl         The Zend Acl instant to add permissions to.
-     * @param string $role        The role (string identifier) to add.
-     * @param array  $permissions The permissions details (array) to add.
-     * @param string $resource    The Acl resource (string identifier) to add roles and permissions into.
+     * @param  Acl    $acl         The Laminas Acl instant to add permissions to.
+     * @param  string $role        The role (string identifier) to add.
+     * @param  array  $permissions The permissions details (array) to add.
+     * @param  string $resource    The Acl resource (string identifier) to add roles and permissions into.
      * @return void
      */
     private function addRoleAndPermissions(Acl &$acl, $role, array $permissions, $resource)

--- a/src/Charcoal/User/AclAwareTrait.php
+++ b/src/Charcoal/User/AclAwareTrait.php
@@ -4,8 +4,8 @@ namespace Charcoal\User;
 
 use RuntimeException;
 
-// From 'zendframework/zend-permissions-acl'
-use Zend\Permissions\Acl\Acl;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
 
 /**
  * Provides access control list.

--- a/src/Charcoal/User/Authorizer.php
+++ b/src/Charcoal/User/Authorizer.php
@@ -8,8 +8,8 @@ use InvalidArgumentException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
-// From 'zendframework/zend-permissions'
-use Zend\Permissions\Acl\Acl;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
 
 // From 'charcoal-user'
 use Charcoal\User\UserInterface;
@@ -23,7 +23,7 @@ use Charcoal\User\UserInterface;
  * The required dependencies are:
  *
  * - `logger` A PSR3 logger instance.
- * - `acl` A Zend ACL (Access-Control-List) instance.
+ * - `acl` A Laminas ACL (Access-Control-List) instance.
  * - `resource` The ACL resource identifier (string).
  *
  * ## Checking permissions

--- a/src/Charcoal/User/ServiceProvider/AuthServiceProvider.php
+++ b/src/Charcoal/User/ServiceProvider/AuthServiceProvider.php
@@ -6,8 +6,8 @@ namespace Charcoal\User\ServiceProvider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
-// From 'zendframework/zend-permissions-acl'
-use Zend\Permissions\Acl\Acl;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
 
 // From 'charcoal-user'
 use Charcoal\User\Authenticator;

--- a/tests/Charcoal/User/Acl/ManagerTest.php
+++ b/tests/Charcoal/User/Acl/ManagerTest.php
@@ -5,9 +5,9 @@ namespace Charcoal\Tests\User\Acl;
 // From Pimple
 use Pimple\Container;
 
-// From 'zendframework/zend-permissions'
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Resource\GenericResource as Resource;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Resource\GenericResource as Resource;
 
 // From 'charcoal-user'
 use Charcoal\User\Acl\Manager;

--- a/tests/Charcoal/User/AuthorizerTest.php
+++ b/tests/Charcoal/User/AuthorizerTest.php
@@ -5,10 +5,10 @@ namespace Charcoal\Tests\User;
 // From Pimple
 use Pimple\Container;
 
-// From 'zendframework/zend-permissions'
-use Zend\Permissions\Acl\Acl;
-use Zend\Permissions\Acl\Role\GenericRole as Role;
-use Zend\Permissions\Acl\Resource\GenericResource as Resource;
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Role\GenericRole as Role;
+use Laminas\Permissions\Acl\Resource\GenericResource as Resource;
 
 // From 'charcoal-user'
 use Charcoal\User\Authorizer;


### PR DESCRIPTION
Related:

- locomotivemtl/charcoal-admin#40

---

Replaced `zendframework/zend-permissions-acl` with `laminas/laminas-permissions-acl`, as per:

The Zend Framework is migrating to the Laminas-branded framework ([source](https://www.zend.com/blog/evolution-zend-framework-laminas-project)).
