### PR TITLE
Improve Authorizer implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.6.x-dev"
+            "dev-master": "0.7.x-dev"
         }
     },
     "require": {

--- a/src/Charcoal/User/AbstractAuthorizer.php
+++ b/src/Charcoal/User/AbstractAuthorizer.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Charcoal\User;
+
+use InvalidArgumentException;
+
+// From PSR-3
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Exception\ExceptionInterface as AclExceptionInterface;
+use Laminas\Permissions\Acl\Resource\ResourceInterface as AclResourceInterface;
+use Laminas\Permissions\Acl\Role\RoleInterface as AclRoleInterface;
+
+// From 'charcoal-user'
+use Charcoal\User\UserInterface;
+
+/**
+ * The base Authorizer service
+ *
+ * The authorizer service helps with user authorization (permission checking).
+ *
+ * ## Constructor dependencies
+ *
+ * Constructor dependencies are passed as an array of `key => value` pair.
+ * The required dependencies are:
+ *
+ * - `logger` A PSR3 logger instance.
+ * - `acl` A Laminas ACL (Access-Control-List) instance.
+ *
+ * ## Checking permissions
+ *
+ * To check if a given ACL (passed in constructor) allows a list of permissions (aka privileges):
+ *
+ * - `xxx(UserInterface $user, string[] $aclPermissions)`
+ */
+abstract class AbstractAuthorizer implements
+    AuthorizerInterface,
+    LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * The ACL service.
+     *
+     * @var Acl
+     */
+    private $acl;
+
+    /**
+     * @param array $data Class dependencies.
+     */
+    public function __construct(array $data)
+    {
+        $this->setLogger($data['logger']);
+        $this->setAcl($data['acl']);
+    }
+
+    /**
+     * Check if access is granted to the role for all permissions.
+     *
+     * @param  AclRoleInterface|string          $role       One ACL role to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null Returns TRUE if and only if all the $privileges are granted against the $role.
+     *     Returns NULL if no applicable role, resource, or permissions could be checked.
+     */
+    public function isRoleGrantedAll($role, $resource, $privileges)
+    {
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        try {
+            foreach ($privileges as $privilege) {
+                if (!$this->isAllowed($role, $resource, $privilege)) {
+                    return false;
+                }
+
+                $result = true;
+            }
+
+            return $result;
+        } catch (AclExceptionInterface $e) {
+            $this->logger->error('[ACL] '.$e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if access is granted to all roles for all permissions.
+     *
+     * @param  AclRoleInterface|string|array    $roles      One or many ACL roles to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null Returns TRUE if and only if all the $privileges are granted against all $roles.
+     *     Returns NULL if no applicable roles, resource, or permissions could be checked.
+     */
+    public function allRolesGrantedAll($roles, $resource, $privileges)
+    {
+        $roles      = (array)$roles;
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        foreach ($roles as $role) {
+            if (!$this->isRoleGrantedAll($role, $resource, $privileges)) {
+                return false;
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if access is granted to any one of the roles for all permissions.
+     *
+     * @param  AclRoleInterface|string|array    $roles      One or many ACL roles to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null Returns TRUE if and only if all the $privileges are granted against any one of the $roles.
+     *     Returns NULL if no applicable roles, resource, or permissions could be checked.
+     */
+    public function anyRolesGrantedAll($roles, $resource, $privileges)
+    {
+        $roles      = (array)$roles;
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        foreach ($roles as $role) {
+            if ($this->isRoleGrantedAll($role, $resource, $privileges)) {
+                return true;
+            }
+
+            $result = false;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if access is granted to the role for any one of the permissions.
+     *
+     * @param  AclRoleInterface|string          $role       One ACL role to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null Returns TRUE if any one of the $privileges are granted against the $role.
+     *     Returns NULL if no applicable role, resource, or permissions could be checked.
+     */
+    public function isRoleGrantedAny($role, $resource, $privileges)
+    {
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        try {
+            foreach ($privileges as $privilege) {
+                if ($this->isAllowed($role, $resource, $privilege)) {
+                    return true;
+                }
+
+                $result = false;
+            }
+
+            return $result;
+        } catch (AclExceptionInterface $e) {
+            $this->logger->error('[ACL] '.$e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if access is granted to all roles for any one of the permissions.
+     *
+     * @param  AclRoleInterface|string|array    $roles      One or many ACL roles to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null Returns TRUE if any one of the $privileges are granted against all $roles.
+     *     Returns NULL if no applicable roles, resource, or permissions could be checked.
+     */
+    public function allRolesGrantedAny($roles, $resource, $privileges)
+    {
+        $roles      = (array)$roles;
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        foreach ($roles as $role) {
+            if (!$this->isRoleGrantedAny($role, $resource, $privileges)) {
+                return false;
+            }
+
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if access is granted to any one of the roles for any one of the permissions.
+     *
+     * @param  AclRoleInterface|string|array    $roles      One or many ACL roles to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null
+     *     Returns TRUE if any one of the $privileges are granted against any one of the $roles.
+     *     Returns NULL if no applicable roles, resource, or permissions could be checked.
+     */
+    public function anyRolesGrantedAny($roles, $resource, $privileges)
+    {
+        $roles      = (array)$roles;
+        $privileges = (array)$privileges;
+        $result     = null;
+
+        foreach ($roles as $role) {
+            if ($this->isRoleGrantedAny($role, $resource, $privileges)) {
+                return true;
+            }
+
+            $result = false;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if access is granted to the user's role(s) for permissions.
+     *
+     * @param  UserInterface                    $user       The user to check.
+     * @param  AclResourceInterface|string|null $resource   One ACL resource to check.
+     * @param  string|string[]                  $privileges One or many ACL privileges to check.
+     * @return boolean|null
+     *     Returns TRUE if and only if the $privileges are granted against one of the roles of the $user.
+     *     Returns NULL if no applicable roles, resource, or permissions could be checked.
+     */
+    public function isUserGranted(UserInterface $user, $resource, $privileges)
+    {
+        return $this->anyRolesGrantedAll($user['roles'], $resource, $privileges);
+    }
+
+
+
+    // Helpers from \Laminas\Permissions\Acl\Acl
+    // =========================================================================
+
+    /**
+     * Check if the role has access to the resource and privilege.
+     *
+     * This method is a proxy to {@see \Laminas\Permissions\Acl\Acl::isAllowed()}.
+     *
+     * @param  AclRoleInterface|string     $role      The ACL role to check.
+     *     If $role is NULL, then the ACL will check for a "blacklist" rule
+     *     (allow everything to all).
+     * @param  AclResourceInterface|string $resource  The ACL resource to check.
+     *     If $resource is NULL, then the ACL will check for a "blacklist" rule
+     *     (allow everything to all).
+     * @param  string                      $privilege The ACL privilege to check.
+     *     If $privilege is NULL, then the ACL returns TRUE if and only if
+     *     the $role is allowed all privileges on the $resource.
+     * @return boolean Returns TRUE if and only if the $role has access to the $resource.
+     */
+    public function isAllowed($role = null, $resource = null, $privilege = null)
+    {
+        return $this->getAcl()->isAllowed($role, $resource, $privilege);
+    }
+
+    /**
+     * Determine if the role is registered.
+     *
+     * @see \Laminas\Permissions\Acl\Acl::hasRole()
+     *
+     * @param  RoleInterface|string $role The ACL role to check.
+     * @return boolean Returns TRUE if and only if the $role exists in the registry.
+     */
+    public function hasRole($role)
+    {
+        return $this->getAcl()->hasRole($role);
+    }
+
+    /**
+     * Determine if the role inherits from another role.
+     *
+     * @see \Laminas\Permissions\Acl\Acl::inheritsRole()
+     *
+     * @param  RoleInterface|string $role        The ACL role to check.
+     * @param  RoleInterface|string $inherit     The ACL role to check $role against.
+     * @param  boolean              $onlyParents Whether the $role must inherit directly from $inherit.
+     * @return boolean Returns TRUE if and only if $role inherits from $inherit.
+     */
+    public function inheritsRole($role, $inherit, $onlyParents = false)
+    {
+        return $this->getAcl()->inheritsRole($role, $inherit, $onlyParents);
+    }
+
+    /**
+     * Determine if the resource is registered.
+     *
+     * @see \Laminas\Permissions\Acl\Acl::hasResource()
+     *
+     * @param  AclResourceInterface|string $resource The ACL resource to check.
+     * @return boolean Returns TRUE if and only if the $resource exists in the ACL.
+     */
+    public function hasResource($resource)
+    {
+        return $this->getAcl()->hasResource($resource);
+    }
+
+    /**
+     * Determine if the resource inherits from another resource.
+     *
+     * @see \Laminas\Permissions\Acl\Acl::inheritsResource()
+     *
+     * @param  AclResourceInterface|string $resource   The ACL resource to check.
+     * @param  AclResourceInterface|string $inherit    The ACL resource to check $resource against.
+     * @param  boolean                     $onlyParent Whether the $resource must inherit directly from $inherit.
+     * @return boolean Returns TRUE if and only if $resource inherits from $inherit.
+     */
+    public function inheritsResource($resource, $inherit, $onlyParent = false)
+    {
+        return $this->getAcl()->inheritsResource($resource, $inherit, $onlyParent);
+    }
+
+
+
+    // Dependencies
+    // =========================================================================
+
+    /**
+     * @return Acl
+     */
+    protected function getAcl()
+    {
+        return $this->acl;
+    }
+
+    /**
+     * @param  Acl $acl The ACL service.
+     * @return void
+     */
+    private function setAcl(Acl $acl)
+    {
+        $this->acl = $acl;
+    }
+}

--- a/src/Charcoal/User/AuthAwareTrait.php
+++ b/src/Charcoal/User/AuthAwareTrait.php
@@ -14,7 +14,7 @@ use Pimple\Container;
 trait AuthAwareTrait
 {
     /**
-     * @var Authenticator
+     * @var AuthenticatorInterface
      */
     private $authenticator;
 
@@ -66,10 +66,10 @@ trait AuthAwareTrait
     /**
      * Set the authentication service.
      *
-     * @param  Authenticator $authenticator The authentication service.
+     * @param  AuthenticatorInterface $authenticator The authentication service.
      * @return void
      */
-    protected function setAuthenticator(Authenticator $authenticator)
+    protected function setAuthenticator(AuthenticatorInterface $authenticator)
     {
         $this->authenticator = $authenticator;
     }
@@ -78,7 +78,7 @@ trait AuthAwareTrait
      * Retrieve the authentication service.
      *
      * @throws RuntimeException If the authenticator was not previously set.
-     * @return Authenticator
+     * @return AuthenticatorInterface
      */
     protected function authenticator()
     {

--- a/src/Charcoal/User/AuthAwareTrait.php
+++ b/src/Charcoal/User/AuthAwareTrait.php
@@ -19,7 +19,7 @@ trait AuthAwareTrait
     private $authenticator;
 
     /**
-     * @var Authorizer
+     * @var AuthorizerInterface
      */
     private $authorizer;
 
@@ -95,10 +95,10 @@ trait AuthAwareTrait
     /**
      * Set the authorization service.
      *
-     * @param  Authorizer $authorizer The authorization service.
+     * @param  AuthorizerInterface $authorizer The authorization service.
      * @return void
      */
-    protected function setAuthorizer(Authorizer $authorizer)
+    protected function setAuthorizer(AuthorizerInterface $authorizer)
     {
         $this->authorizer = $authorizer;
     }
@@ -107,7 +107,7 @@ trait AuthAwareTrait
      * Retrieve the authorization service.
      *
      * @throws RuntimeException If the authorizer was not previously set.
-     * @return Authorizer
+     * @return AuthorizerInterface
      */
     protected function authorizer()
     {

--- a/src/Charcoal/User/AuthorizerInterface.php
+++ b/src/Charcoal/User/AuthorizerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Charcoal\User;
+
+// From 'laminas/laminas-permissions-acl'
+use Laminas\Permissions\Acl\AclInterface;
+
+/**
+ * Authorizer Interface
+ */
+interface AuthorizerInterface extends AclInterface
+{
+    /**
+     * Determine if the role is registered.
+     *
+     * @see \Laminas\Permissions\Acl\Acl::hasRole()
+     *
+     * @param  Laminas\Permissions\Acl\Role\RoleInterface|string $role The ACL role to check.
+     * @return boolean Returns TRUE if and only if the $role exists in the registry.
+     */
+    public function hasRole($role);
+}

--- a/tests/Charcoal/ReflectionsTrait.php
+++ b/tests/Charcoal/ReflectionsTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Charcoal\Tests;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Utilities for testing non-public methods and properties.
+ */
+trait ReflectionsTrait
+{
+    /**
+     * Gets a {@see ReflectionMethod} for a class method.
+     *
+     * The method will be made accessible in the process.
+     *
+     * @param  mixed  $class The class name or object that contains the method.
+     * @param  string $name  The method name to reflect.
+     * @return ReflectionMethod
+     */
+    public function getMethod($class, $name)
+    {
+        $reflected = new ReflectionMethod($class, $name);
+        $reflected->setAccessible(true);
+        return $reflected;
+    }
+
+    /**
+     * Invoke the requested method, via the Reflection API.
+     *
+     * @param  mixed  $object The object that contains the method.
+     * @param  string $name   The method name to invoke.
+     * @param  array  $args   The parameters to be passed to the function.
+     * @return mixed Returns the method result.
+     */
+    public function callMethod($object, $name, array $args = [])
+    {
+        $method = $this->getMethod($object, $name);
+        if (empty($args)) {
+            return $method->invoke($object);
+        } else {
+            return $method->invokeArgs($object, $args);
+        }
+    }
+
+    /**
+     * Invoke the requested method with arguments, via the Reflection API.
+     *
+     * @param  mixed  $object  The object that contains the method.
+     * @param  string $name    The method name to invoke.
+     * @param  mixed  ...$args The parameters to be passed to the function.
+     * @return mixed Returns the method result.
+     */
+    public function callMethodWith($object, $name, ...$args)
+    {
+        return $this->getMethod($object, $name)->invoke($object, ...$args);
+    }
+
+    /**
+     * Gets a {@see ReflectionProperty} for a class property.
+     *
+     * The property will be made accessible in the process.
+     *
+     * @param  mixed  $class The class name or object that contains the property.
+     * @param  string $name  The property name to reflect.
+     * @return ReflectionProperty
+     */
+    public function getProperty($class, $name)
+    {
+        $reflected = new ReflectionProperty($class, $name);
+        $reflected->setAccessible(true);
+        return $reflected;
+    }
+
+    /**
+     * Gets class property value, via the Reflection API.
+     *
+     * @param  mixed  $object The object to access.
+     * @param  string $name   The property name to fetch.
+     * @return mixed
+     */
+    public function getPropertyValue($object, $name)
+    {
+        return $this->getProperty($object, $name)->getValue($object);
+    }
+
+    /**
+     * Set class property value, via the Reflection API.
+     *
+     * @param  mixed  $object The object to access.
+     * @param  string $name   The property name to affect.
+     * @param  mixed  $value  The new value.
+     * @return void
+     */
+    public function setPropertyValue($object, $name, $value)
+    {
+        $this->getProperty($object, $name)->setValue($object, $value);
+    }
+}

--- a/tests/Charcoal/User/AuthorizerTest.php
+++ b/tests/Charcoal/User/AuthorizerTest.php
@@ -7,12 +7,17 @@ use Pimple\Container;
 
 // From 'laminas/laminas-permissions-acl'
 use Laminas\Permissions\Acl\Acl;
-use Laminas\Permissions\Acl\Role\GenericRole as Role;
+use Laminas\Permissions\Acl\Exception\ExceptionInterface as AclExceptionInterface;
 use Laminas\Permissions\Acl\Resource\GenericResource as Resource;
+use Laminas\Permissions\Acl\Role\GenericRole as Role;
 
 // From 'charcoal-user'
+use Charcoal\User\AbstractAuthorizer;
 use Charcoal\User\Authorizer;
+use Charcoal\User\AuthorizerInterface;
+use Charcoal\User\GenericUser;
 use Charcoal\Tests\AbstractTestCase;
+use Charcoal\Tests\ReflectionsTrait;
 use Charcoal\Tests\User\ContainerProvider;
 
 /**
@@ -20,12 +25,14 @@ use Charcoal\Tests\User\ContainerProvider;
  */
 class AuthorizerTest extends AbstractTestCase
 {
+    use ReflectionsTrait;
+
     /**
      * Tested Class.
      *
      * @var Authorizer
      */
-    private $obj;
+    private $auth;
 
     /**
      * Store the ACL manager.
@@ -51,11 +58,143 @@ class AuthorizerTest extends AbstractTestCase
         $container = $this->container();
 
         $this->acl = new Acl();
-        $this->obj = new Authorizer([
+        $this->acl->addResource('area');
+        $this->acl->addRole('guest');
+
+        $this->auth = $this->createAuthorizer();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUpComplexRolesAndPrivileges()
+    {
+        $this->acl->addRole('staff', 'guest');
+        $this->acl->addRole('aide', 'guest');
+        $this->acl->addRole('editor', 'staff');
+        $this->acl->addRole('admin');
+
+        // Guest may only "view" content
+        $this->acl->allow('guest', null, 'view');
+
+        // Assistant inherits "view" privilege from guest,
+        // but also needs additional privileges
+        $this->acl->allow('aide', null, [ 'edit', 'revise' ]);
+
+        // Staff inherits "view" privilege from guest,
+        // but also needs additional privileges
+        $this->acl->allow('staff', null, [ 'edit', 'submit', 'revise' ]);
+
+        // Editor inherits "view", "edit", "submit", and "revise" privileges from
+        // staff, but also needs additional privileges
+        $this->acl->allow('editor', null, [ 'publish', 'archive', 'delete' ]);
+
+        // Administrator is allowed all privileges
+        $this->acl->allow('admin');
+    }
+
+    /**
+     * Create an Authorizer instance.
+     *
+     * @param  array $data Class dependencies.
+     * @return Authorizer
+     */
+    protected function createAuthorizer(array $data = [])
+    {
+        $container = $this->container();
+
+        $data += [
             'logger'    => $container['logger'],
             'acl'       => $this->acl,
-            'resource'  => 'test'
+            'resource'  => 'area',
+        ];
+
+        $authorizer = new Authorizer($data);
+
+        return $authorizer;
+    }
+
+    /**
+     * Create a mock Authorizer instance.
+     *
+     * @param  array $data Class dependencies.
+     * @return MockObject&AuthorizerInterface
+     */
+    protected function mockAuthorizer(array $data = [])
+    {
+        $container = $this->container();
+
+        $data += [
+            'logger'    => $container['logger'],
+            'acl'       => $this->acl,
+            'resource'  => 'area',
+        ];
+
+        $stub = $this->getMockForAbstractClass(AbstractAuthorizer::class, [ $data ]);
+
+        return $stub;
+    }
+
+    /**
+     * Create a user instance.
+     *
+     * @return GenericUser
+     */
+    protected function createUser()
+    {
+        $container = $this->container();
+
+        $user = $container['model/factory']->create(GenericUser::class);
+
+        return $user;
+    }
+
+
+
+    // Authorizer
+    // =========================================================================
+
+    /**
+     * @return void
+     */
+    public function testSetDefaultResourceWithNull()
+    {
+        $container = $this->container();
+
+        $authorizer = $this->createAuthorizer([
+            'resource' => null
         ]);
+        $auth = new Authorizer([
+            'logger'    => $container['logger'],
+            'acl'       => $this->acl,
+            'resource'  => null,
+        ]);
+
+        $this->assertNull($this->callMethod($auth, 'getDefaultResource'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     *
+     * @return void
+     */
+    public function testSetDefaultResourceWithBadValue()
+    {
+        $container = $this->container();
+
+        $auth = new Authorizer([
+            'logger'    => $container['logger'],
+            'acl'       => $this->acl,
+            'resource'  => 35,
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRolesAllowedWithoutPermissions()
+    {
+        $this->assertTrue($this->auth->rolesAllowed([ 'guest' ], []));
     }
 
     /**
@@ -63,20 +202,230 @@ class AuthorizerTest extends AbstractTestCase
      */
     public function testRolesAllowed()
     {
-        $acl = $this->acl;
-        $acl->addResource('test');
+        $this->assertFalse($this->auth->rolesAllowed([ 'guest' ], [ 'privilege1' ]));
 
-        $acl->addRole('foo');
-        $this->assertFalse($this->obj->rolesAllowed([ 'foo' ], [ 'bar' ]));
+        $this->acl->allow('guest', 'area', 'privilege1');
+        $this->assertTrue($this->auth->rolesAllowed([ 'guest' ], [ 'privilege1' ]));
+        $this->assertFalse($this->auth->rolesAllowed([ 'guest' ], [ 'privilege1', 'privilege2' ]));
 
-        $acl->allow('foo', 'test', 'bar');
-        $this->assertTrue($this->obj->rolesAllowed([ 'foo' ], [ 'bar' ]));
+        $this->assertFalse($this->auth->rolesAllowed([ null ], [ 'privilege1' ]));
 
-        $this->assertFalse($this->obj->rolesAllowed([ null ], [ 'bar' ]));
-
-        $acl->allow(null, 'test');
-        $this->assertTrue($this->obj->rolesAllowed([ null ], [ 'bar' ]));
+        $this->acl->allow(null, 'area');
+        $this->assertTrue($this->auth->rolesAllowed([ null ], [ 'privilege1' ]));
     }
+
+    /**
+     * @return void
+     */
+    public function testUserAllowedWithoutPermissions()
+    {
+        $user = $this->createUser();
+        $user['roles'] = 'guest';
+
+        $this->assertTrue($this->auth->userAllowed($user, []));
+    }
+
+    /**
+     * @return void
+     */
+    public function testUserAllowed()
+    {
+        $user = $this->createUser();
+        $user['roles'] = 'guest';
+
+        $this->assertFalse($this->auth->userAllowed($user, [ 'privilege1' ]));
+
+        $this->acl->allow('guest', 'area', 'privilege1');
+        $this->assertTrue($this->auth->userAllowed($user, [ 'privilege1' ]));
+        $this->assertFalse($this->auth->userAllowed($user, [ 'privilege1', 'privilege2' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAllowedWithDefaultResource()
+    {
+        $this->acl->allow('guest', 'area', 'privilege1');
+        $this->assertFalse($this->auth->isAllowed('guest', null, 'privilege1'));
+        $this->assertTrue($this->auth->isAllowed('guest', 'area', 'privilege1'));
+        $this->assertTrue($this->auth->isAllowed('guest', Authorizer::DEFAULT_RESOURCE, 'privilege1'));
+    }
+
+
+
+    // AbstractAuthorizer
+    // =========================================================================
+
+    /**
+     * @return void
+     */
+    public function testIsRoleGrantedCatchesAclExceptions()
+    {
+        $this->acl->allow('guest', null, [ 'privilege1', 'privilege2', 'privilege3' ]);
+        $this->acl->deny('guest', null, [ 'privilege4', 'privilege5' ]);
+
+        $this->assertNull($this->auth->isRoleGrantedAll('stranger', null, 'privilege1'));
+        $this->assertNull($this->auth->isRoleGrantedAll('guest', 'nonexistent', 'privilege1'));
+
+        $this->assertNull($this->auth->isRoleGrantedAny('stranger', null, [ 'privilege1', 'privilege4' ]));
+        $this->assertNull($this->auth->isRoleGrantedAny('guest', 'nonexistent', [ 'privilege4', 'privilege5' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsRoleGrantedAll()
+    {
+        $this->acl->allow('guest', null, [ 'privilege1', 'privilege2', 'privilege3' ]);
+        $this->acl->deny('guest', null, 'privilege4');
+
+        $this->assertTrue($this->auth->isRoleGrantedAll('guest', null, [ 'privilege1', 'privilege2' ]));
+        $this->assertFalse($this->auth->isRoleGrantedAll('guest', null, [ 'privilege1', 'privilege4' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testAllRolesGrantedAll()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $this->assertTrue($this->auth->allRolesGrantedAll([ 'aide', 'staff' ], null, [ 'edit', 'revise' ]));
+        $this->assertFalse($this->auth->allRolesGrantedAll([ 'aide', 'staff' ], null, [ 'edit', 'submit' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnyRolesGrantedAll()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $this->assertTrue($this->auth->anyRolesGrantedAll([ 'aide', 'staff' ], null, [ 'edit', 'submit' ]));
+        $this->assertFalse($this->auth->anyRolesGrantedAll([ 'aide', 'staff' ], null, [ 'edit', 'publish' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsRoleGrantedAny()
+    {
+        $this->acl->allow('guest', null, [ 'privilege1', 'privilege2', 'privilege3' ]);
+        $this->acl->deny('guest', null, [ 'privilege4', 'privilege5' ]);
+
+        $this->assertTrue($this->auth->isRoleGrantedAny('guest', null, [ 'privilege1', 'privilege4' ]));
+        $this->assertFalse($this->auth->isRoleGrantedAny('guest', null, [ 'privilege4', 'privilege5' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testAllRolesGrantedAny()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $this->assertTrue($this->auth->allRolesGrantedAny([ 'aide', 'staff' ], null, [ 'edit', 'submit' ]));
+        $this->assertFalse($this->auth->allRolesGrantedAny([ 'aide', 'staff' ], null, [ 'publish', 'other' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testAnyRolesGrantedAny()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $this->assertTrue($this->auth->anyRolesGrantedAny([ 'aide', 'staff' ], null, [ 'submit', 'other' ]));
+        $this->assertFalse($this->auth->anyRolesGrantedAny([ 'aide', 'staff' ], null, [ 'publish', 'other' ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsUserGrantedWithoutPermissions()
+    {
+        $user = $this->createUser();
+        $user['roles'] = 'guest';
+
+        $this->assertFalse($this->auth->isUserGranted($user, null, null));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsUserGranted()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $user = $this->createUser();
+        $user['roles'] = [ 'aide', 'staff' ];
+
+        $this->assertTrue($this->auth->isUserGranted($user, null, [ 'edit', 'submit' ]));
+        $this->assertFalse($this->auth->isUserGranted($user, null, [ 'edit', 'publish' ]));
+    }
+
+
+
+    // ACL
+    // =========================================================================
+
+    /**
+     * Ensures that by default, Laminas ACL denies access to everything by all.
+     *
+     * @return void
+     */
+    public function testDefaultDeny()
+    {
+        $this->assertFalse($this->auth->isAllowed());
+    }
+
+    /**
+     * Ensures that by default, Laminas ACL can allow access to everything by all.
+     *
+     * @return void
+     */
+    public function testDefaultAllow()
+    {
+        $this->acl->allow();
+        $this->assertTrue($this->auth->isAllowed());
+    }
+
+    /**
+     * @return void
+     */
+    public function testProxyMethods()
+    {
+        $this->setUpComplexRolesAndPrivileges();
+
+        $authorizer = $this->createAuthorizer();
+
+        $this->assertTrue($authorizer->hasRole('guest'));
+        $this->assertFalse($authorizer->hasRole('visitor'));
+
+        $this->assertTrue($authorizer->hasResource('area'));
+        $this->assertFalse($authorizer->hasResource('nonexistent'));
+
+        $this->assertTrue($authorizer->inheritsRole('editor', 'guest'));
+        $this->assertFalse($authorizer->inheritsRole('admin', 'guest'));
+
+        $this->assertTrue($authorizer->inheritsRole('editor', 'staff', true));
+        $this->assertFalse($authorizer->inheritsRole('editor', 'guest', true));
+
+        $this->acl->addResource('city');
+        $this->acl->addResource('building', 'city');
+        $this->acl->addResource('room', 'building');
+
+        $this->assertTrue($authorizer->inheritsResource('room', 'city'));
+        $this->assertFalse($authorizer->inheritsResource('building', 'room'));
+
+        $this->assertTrue($authorizer->inheritsResource('building', 'city', true));
+        $this->assertFalse($authorizer->inheritsResource('room', 'city', true));
+    }
+
+
+
+    // Dependencies
+    // =========================================================================
 
     /**
      * Set up the service container.
@@ -89,6 +438,7 @@ class AuthorizerTest extends AbstractTestCase
             $container = new Container();
             $containerProvider = new ContainerProvider();
             $containerProvider->registerBaseServices($container);
+            $containerProvider->registerModelFactory($container);
 
             $this->container = $container;
         }


### PR DESCRIPTION
The `Authorizer` now extends and interface, an abstract class, and a variety of new methods to check permissions against roles and resources.

Previously, the Authorizer provided a limited interface for interacting with the ACL and evaluating permissions against roles (one issue being the lack of support for multiple roles).

### Old API

- `rolesAllowed()` — Deprecated in favour of `anyRolesGrantedAll()`
- `userAllowed()` — Deprecated in favour of `anyRolesGrantedAll()` (via `isUserGranted()`)
- `resource` renamed to `defaultResource`

Internally, the old permission checking methods now use the new methods (which fixes support for multiple roles) but preserves the default behavior of allowing access to everything.

### New API

- `isRoleGrantedAll()` — Check if access is granted to the role, and the resource, for all permissions.
  - `allRolesGrantedAll()` — Check if access is granted to all roles, and the resource, for all permissions.
  - `anyRolesGrantedAll()` — Check if access is granted to any one of the roles, and the resource, for all permissions.
  - `isUserGranted()` — Check if access is granted to the user's role(s), and the resource, for permissions.
- `isRoleGrantedAny()` — Check if access is granted to the role, and the resource, for any one of the permissions.
  - `allRolesGrantedAny()` — Check if access is granted to all roles, and the resource, for any one of the permissions.
  - `anyRolesGrantedAny()` — Check if access is granted to any one of the roles, and the resource, for any one of the permissions.
- `isAllowed()` — Check if the role has access to the resource and privilege.
- `hasRole()` — Check if the role is registered.
- `inheritsRole()` — Check if the role inherits from another role.
- `hasResource()` — Check if the resource is registered.
- `inheritsResource()` — Check if the resource inherits from another resource.

### Example

#### Example #&#8203;1

Using the new API with the default "charcoal" resource.

```php
if (!$authorizer->isUserGranted($user, Authorizer::DEFAULT_RESOURCE, 'edit')) {
    return $response->withStatus(403);
}
```

#### Example #&#8203;2

```php
public function isAuthorizedToManageOthers()
{
    $obj        = $this->obj();
    $objType    = $obj->objType();
    $authorizer = $this->authorizer();

    if ($authorizer->hasResource($objType)) {
        $user = $this->authenticator()->getUser();
        if ($user) {
            return $authorizer->isUserGranted($user, $objType, 'object/manage/others');
        }
    }

    return false;
}

protected function prepareAuthorship(ModelInterface $obj)
{
    $old    = $this->prevObj;
    $userId = $this->authenticator()->getUserId();

    if ($old->hasAuthor($userId) && !$obj->hasAuthor($userId)) {
        // Redirect if current user is no longer an author
        if (!$this->isAuthorizedToManageOthers()) {
            $url = $this->getObjectBrowseUrl();
            $url = $obj->renderTemplate($url);
            $this->setSuccessUrl($url);
        }
    }
}
```